### PR TITLE
Make raycasting more reliable

### DIFF
--- a/DeviationCorrector/Program.cs
+++ b/DeviationCorrector/Program.cs
@@ -450,7 +450,7 @@ namespace IngameScript
                     RaycastArray.Add(block as IMyCameraBlock);
                     ((IMyCameraBlock)block).EnableRaycast = true;
                 }
-                RC = new RaycastHoming(RaycastRange);
+                RC = new RaycastHoming(RaycastRange, 3, 250, Me.CubeGrid.EntityId);
             }
 
             GridTerminalSystem.GetBlocksOfType(Controllers);


### PR DESCRIPTION
Use same maxTimeForLockBreak as WHAM, and set min distance to 250m and ignore grid to self to avoid targeting one of our own grids.